### PR TITLE
optmize proofs contrustion algorithm

### DIFF
--- a/tree_test.go
+++ b/tree_test.go
@@ -288,7 +288,18 @@ func BenchmarkAppendHash(b *testing.B) {
 
 func BenchmarkInclusionProof(b *testing.B) {
 	s := NewMemStore()
+	for i := 0; i <= b.N; i++ {
+		Append(s, []byte{0, 1, 3, 4, 5, 6, 7})
+	}
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		InclusionProof(s, uint64(i), uint64(i/2))
+	}
+}
+
+func BenchmarkInclusionProofOfLastNode(b *testing.B) {
+	s := NewMemStore()
+	for i := 0; i <= b.N; i++ {
 		Append(s, []byte{0, 1, 3, 4, 5, 6, 7})
 	}
 	b.ResetTimer()


### PR DESCRIPTION
Rewrote internal MTH computation, see the [function comment](https://github.com/codenotary/merkletree/pull/3/files#diff-37cf0fd7a164303538a2d22d965646dfR122).

Best case
```
BEFORE
pkg: github.com/codenotary/merkletree
BenchmarkInclusionProofOfLastNode-8   	 1422026	      1188 ns/op	    2131 B/op	      19 allocs/op


AFTER
pkg: github.com/codenotary/merkletree
BenchmarkInclusionProofOfLastNode-8   	 1000000	      1117 ns/op	    2082 B/op	      18 allocs/op
```

Average (~165x improvement)
```
BEFORE
pkg: github.com/codenotary/merkletree
BenchmarkInclusionProof-8   	   10000	    710169 ns/op	   43988 B/op	    1303 allocs/op

AFTER
pkg: github.com/codenotary/merkletree
BenchmarkInclusionProof-8   	  307402	      4312 ns/op	    5870 B/op	      40 allocs/op
```


